### PR TITLE
feat: add onSubgraphError

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ main()
           - `adapter(partialResult)` (function, optional) - When resolving an entity across multiple subgraphs, an initial query is made to one subgraph followed by one or more followup queries to other subgraphs. The initial query must return enough information to identify the corresponding data in the other subgraphs. This function is invoked with the result of the initial query. It should return an object whose keys correspond to the `primaryKeyFields` configuration.
           - `primaryKeyFields` (array of strings, required) - The fields used to uniquely identify objects of this type.
           - `referenceListResolverName` (string, required) - The name of a resolver used to retrieve a list of objects by their primary keys.
-      - `onSubgraphError` (function, optional) - Hook called when an error occurs getting schema from a subgraph. The arguments are:
+      - `onSubgraphError` (function, required) - Hook called when an error occurs getting schema from a subgraph. The arguments are:
           - `error` (error) - The error.
           - `subgraph` (error) - The erroring subgraph.
       - `subscriptions` (object, optional) - Subscription hooks. This is required if subscriptions are used. This object adheres to the following schema.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ main()
           - `adapter(partialResult)` (function, optional) - When resolving an entity across multiple subgraphs, an initial query is made to one subgraph followed by one or more followup queries to other subgraphs. The initial query must return enough information to identify the corresponding data in the other subgraphs. This function is invoked with the result of the initial query. It should return an object whose keys correspond to the `primaryKeyFields` configuration.
           - `primaryKeyFields` (array of strings, required) - The fields used to uniquely identify objects of this type.
           - `referenceListResolverName` (string, required) - The name of a resolver used to retrieve a list of objects by their primary keys.
-      - `onSubgraphError` (function, required) - Hook called when an error occurs getting schema from a subgraph. The arguments are:
+      - `onSubgraphError` (function, optional) - Hook called when an error occurs getting schema from a subgraph. The default function will throw the error. The arguments are:
           - `error` (error) - The error.
           - `subgraph` (error) - The erroring subgraph.
       - `subscriptions` (object, optional) - Subscription hooks. This is required if subscriptions are used. This object adheres to the following schema.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ main()
           - `referenceListResolverName` (string, required) - The name of a resolver used to retrieve a list of objects by their primary keys.
       - `onSubgraphError` (function, optional) - Hook called when an error occurs getting schema from a subgraph. The default function will throw the error. The arguments are:
           - `error` (error) - The error.
-          - `subgraph` (error) - The erroring subgraph.
+          - `subgraph` (object) - The erroring subgraph.
       - `subscriptions` (object, optional) - Subscription hooks. This is required if subscriptions are used. This object adheres to the following schema.
         - `onError(ctx, topic, error)` (function, required) - Hook called when a subscription error occurs. The arguments are:
           - `ctx` (any) - GraphQL context object.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ main()
           - `adapter(partialResult)` (function, optional) - When resolving an entity across multiple subgraphs, an initial query is made to one subgraph followed by one or more followup queries to other subgraphs. The initial query must return enough information to identify the corresponding data in the other subgraphs. This function is invoked with the result of the initial query. It should return an object whose keys correspond to the `primaryKeyFields` configuration.
           - `primaryKeyFields` (array of strings, required) - The fields used to uniquely identify objects of this type.
           - `referenceListResolverName` (string, required) - The name of a resolver used to retrieve a list of objects by their primary keys.
+      - `onSubgraphError` (function, optional) - Hook called when an error occurs getting schema from a subgraph. The arguments are:
+          - `error` (error) - The error.
+          - `subgraph` (error) - The erroring subgraph.
       - `subscriptions` (object, optional) - Subscription hooks. This is required if subscriptions are used. This object adheres to the following schema.
         - `onError(ctx, topic, error)` (function, required) - Hook called when a subscription error occurs. The arguments are:
           - `ctx` (any) - GraphQL context object.

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -31,7 +31,7 @@ class Composer {
       mutationTypeName = 'Mutation',
       subscriptionTypeName = 'Subscription',
       subgraphs = [],
-      onSubgraphError = ({ error }) => { throw error },
+      onSubgraphError = onError,
       subscriptions
     } = options
 
@@ -238,7 +238,7 @@ class Composer {
         const endpoint = `${subgraph.server.host}${subgraph.server.composeEndpoint}`
         const msg = `Could not process schema from '${endpoint}'`
 
-        this.onSubgraphError({ subgraph: { ...subgraph }, error: new Error(msg, { cause: responses[i].reason }) })
+        this.onSubgraphError(new Error(msg, { cause: responses[i].reason }), { ...subgraph })
         continue
       }
 
@@ -594,5 +594,7 @@ function createDefaultAdapter (name, keyFields) {
     return result
   }
 }
+
+function onError (error) { throw error }
 
 module.exports = { Composer }

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -31,7 +31,7 @@ class Composer {
       mutationTypeName = 'Mutation',
       subscriptionTypeName = 'Subscription',
       subgraphs = [],
-      onSubgraphError,
+      onSubgraphError = ({ error }) => { throw error },
       subscriptions
     } = options
 

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -39,12 +39,7 @@ class Composer {
     validateString(mutationTypeName, 'mutationTypeName')
     validateString(subscriptionTypeName, 'subscriptionTypeName')
     validateArray(subgraphs, 'subgraphs')
-    if (onSubgraphError) {
-      validateFunction(onSubgraphError, 'onSubgraphError')
-      this.onSubgraphError = onSubgraphError
-    } else {
-      this.onSubgraphError = noop
-    }
+    validateFunction(onSubgraphError, 'onSubgraphError')
 
     if (subscriptions) {
       validateObject(subscriptions, 'subscriptions')
@@ -177,6 +172,7 @@ class Composer {
     this.#types = new Map()
     this.#directives = new Map()
     this.resolvers = Object.create(null)
+    this.onSubgraphError = onSubgraphError
     this.subscriptionMap = new Map()
     this.onSubscriptionEnd = onSubscriptionEnd.bind(this)
   }
@@ -598,6 +594,5 @@ function createDefaultAdapter (name, keyFields) {
     return result
   }
 }
-function noop () {}
 
 module.exports = { Composer }

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -31,6 +31,7 @@ class Composer {
       mutationTypeName = 'Mutation',
       subscriptionTypeName = 'Subscription',
       subgraphs = [],
+      onSubgraphError,
       subscriptions
     } = options
 
@@ -38,6 +39,12 @@ class Composer {
     validateString(mutationTypeName, 'mutationTypeName')
     validateString(subscriptionTypeName, 'subscriptionTypeName')
     validateArray(subgraphs, 'subgraphs')
+    if (onSubgraphError) {
+      validateFunction(onSubgraphError, 'onSubgraphError')
+      this.onSubgraphError = onSubgraphError
+    } else {
+      this.onSubgraphError = noop
+    }
 
     if (subscriptions) {
       validateObject(subscriptions, 'subscriptions')
@@ -231,11 +238,12 @@ class Composer {
       const { status, value: introspection } = responses[i]
 
       if (status !== 'fulfilled') {
-        const { server } = this.#subgraphs[i]
-        const endpoint = `${server.host}${server.composeEndpoint}`
+        const subgraph = this.#subgraphs[i]
+        const endpoint = `${subgraph.server.host}${subgraph.server.composeEndpoint}`
         const msg = `Could not process schema from '${endpoint}'`
 
-        throw new Error(msg, { cause: responses[i].reason })
+        this.onSubgraphError({ subgraph: { ...subgraph }, error: new Error(msg, { cause: responses[i].reason }) })
+        continue
       }
 
       schemas.push(introspection)
@@ -417,12 +425,12 @@ class Composer {
         try {
           client?.unsubscribeAll()
           client?.close()
-        } catch {} // Ignore error.
+        } catch { } // Ignore error.
 
         // Close the connection from the client.
         try {
           pubsub.unsubscribe(contextValue, topic)
-        } catch {} // Ignore error.
+        } catch { } // Ignore error.
       }
 
       client = new SubscriptionClient(wsUrl, {
@@ -590,5 +598,6 @@ function createDefaultAdapter (name, keyFields) {
     return result
   }
 }
+function noop () {}
 
 module.exports = { Composer }

--- a/test/composer.js
+++ b/test/composer.js
@@ -128,7 +128,7 @@ test('should handle partial subgraphs', async (t) => {
   {
     let errors = 0
     const composer = await compose({
-      onSubgraphError: ({ error }) => {
+      onSubgraphError: (error) => {
         assert.strictEqual(error.message, `Could not process schema from '${services[0].host}/get-introspection'`)
         errors++
       },
@@ -151,7 +151,7 @@ test('should handle all the unreachable subgraphs', async (t) => {
   let errors = 0
 
   const composer = await compose({
-    onSubgraphError: ({ error }) => {
+    onSubgraphError: (error) => {
       assert.strictEqual(error.message, "Could not process schema from 'http://unreachable.local/.well-known/graphql-composition'")
       errors++
     },

--- a/test/composer.js
+++ b/test/composer.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const assert = require('node:assert')
 const { test } = require('node:test')
 
@@ -29,15 +30,20 @@ test('should get sdl from composer', async (t) => {
       resolvers: { Query: { sub: (_, { x, y }) => x - y } }
     }]
   const expectedSdl = 'type Query {\n' +
-  '  add(x: Int, y: Int): Int\n' +
-  '  mul(a: Int, b: Int): Int\n' +
-  '  sub(x: Int, y: Int): Int\n' +
-  '}'
+    '  add(x: Int, y: Int): Int\n' +
+    '  mul(a: Int, b: Int): Int\n' +
+    '  sub(x: Int, y: Int): Int\n' +
+    '}'
 
   for (const service of services) {
     const instance = await startGraphqlService(t, {
-      schema: service.schema,
-      resolvers: service.resolvers
+      mercurius: {
+        schema: service.schema,
+        resolvers: service.resolvers
+      },
+      exposeIntrospection: {
+        path: '/get-introspection'
+      }
     })
     service.host = await instance.listen()
   }
@@ -47,7 +53,7 @@ test('should get sdl from composer', async (t) => {
       {
         server: {
           host: service.host,
-          composeEndpoint: '/graphql-composition',
+          composeEndpoint: '/get-introspection',
           graphqlEndpoint: '/graphql'
         }
       }
@@ -60,4 +66,143 @@ test('should get sdl from composer', async (t) => {
   })
 
   assert.strictEqual(expectedSdl, composer.toSdl())
+  assert.equal(expectedSdl, composer.toSdl())
+})
+
+test('should handle partial subgraphs', async (t) => {
+  const services = [
+    {
+      schema: 'type Query { add(x: Int, y: Int): Int }',
+      resolvers: { Query: { add: (_, { x, y }) => x + y } }
+    },
+    {
+      schema: 'type Query { mul(a: Int, b: Int): Int }',
+      resolvers: { Query: { mul: (_, { a, b }) => a * b } }
+    },
+    {
+      schema: 'type Query { sub(x: Int, y: Int): Int }',
+      resolvers: { Query: { sub: (_, { x, y }) => x - y } }
+    }]
+
+  for (const service of services) {
+    service.instance = await startGraphqlService(t, {
+      mercurius: {
+        schema: service.schema,
+        resolvers: service.resolvers
+      },
+      exposeIntrospection: {
+        path: '/get-introspection'
+      }
+    })
+    service.host = await service.instance.listen()
+  }
+  const expectedSdl1 = 'type Query {\n' +
+    '  add(x: Int, y: Int): Int\n' +
+    '  mul(a: Int, b: Int): Int\n' +
+    '  sub(x: Int, y: Int): Int\n' +
+    '}'
+  const expectedSdl2 = 'type Query {\n' +
+    '  mul(a: Int, b: Int): Int\n' +
+    '  sub(x: Int, y: Int): Int\n' +
+    '}'
+
+  {
+    const composer = await compose({
+      subgraphs: services.map(service => (
+        {
+          server: {
+            host: service.host,
+            composeEndpoint: '/get-introspection',
+            graphqlEndpoint: '/graphql'
+          }
+        }
+      ))
+    })
+    assert.equal(expectedSdl1, composer.toSdl())
+  }
+
+  await services[0].instance.close()
+
+  {
+    const composer = await compose({
+      subgraphs: services.map(service => (
+        {
+          server: {
+            host: service.host,
+            composeEndpoint: '/get-introspection',
+            graphqlEndpoint: '/graphql'
+          }
+        }
+      ))
+    })
+    assert.equal(expectedSdl2, composer.toSdl())
+  }
+})
+
+test('should handle all the unreachable subgraphs', async (t) => {
+  const composer = await compose({
+    subgraphs: [
+      {
+        server: {
+          host: 'http://unreachable.local'
+        }
+      }
+    ]
+  })
+  assert.equal('', composer.toSdl())
+  assert.deepEqual({}, composer.resolvers)
+})
+
+test('should fire onSubgraphError retrieving subgraphs from unreachable services', async (t) => {
+  const services = [
+    {
+      off: true,
+      schema: 'type Query { add(x: Int, y: Int): Int }',
+      resolvers: { Query: { add: (_, { x, y }) => x + y } }
+    },
+    {
+      off: true,
+      schema: 'type Query { mul(a: Int, b: Int): Int }',
+      resolvers: { Query: { mul: (_, { a, b }) => a * b } }
+    },
+    {
+      schema: 'type Query { sub(x: Int, y: Int): Int }',
+      resolvers: { Query: { sub: (_, { x, y }) => x - y } }
+    }]
+  const expectedSdl = 'type Query {\n' +
+    '  sub(x: Int, y: Int): Int\n' +
+    '}'
+  const expectedErrorMessage = "Could not process schema from 'http://unreachable.local/.well-known/graphql-composition'"
+
+  for (const service of services) {
+    if (service.off) {
+      service.host = 'http://unreachable.local'
+      continue
+    }
+    service.instance = await startGraphqlService(t, {
+      mercurius: {
+        schema: service.schema,
+        resolvers: service.resolvers
+      }
+    })
+    service.host = await service.instance.listen()
+  }
+
+  let errors = 0
+  const composer = await compose({
+    subgraphs: services.map(service => (
+      {
+        server: {
+          host: service.host
+        }
+      }
+    )),
+    onSubgraphError: ({ error }) => {
+      assert.equal(expectedErrorMessage, error.message)
+      errors++
+    }
+  })
+
+  assert.equal(errors, 2)
+  assert.equal(expectedSdl, composer.toSdl())
 })

--- a/test/composer.js
+++ b/test/composer.js
@@ -49,6 +49,7 @@ test('should get sdl from composer', async (t) => {
   }
 
   const composer = await compose({
+    onSubgraphError: () => {},
     subgraphs: services.map(service => (
       {
         server: {
@@ -66,7 +67,6 @@ test('should get sdl from composer', async (t) => {
   })
 
   assert.strictEqual(expectedSdl, composer.toSdl())
-  assert.equal(expectedSdl, composer.toSdl())
 })
 
 test('should handle partial subgraphs', async (t) => {
@@ -108,6 +108,7 @@ test('should handle partial subgraphs', async (t) => {
 
   {
     const composer = await compose({
+      onSubgraphError: () => {},
       subgraphs: services.map(service => (
         {
           server: {
@@ -118,13 +119,14 @@ test('should handle partial subgraphs', async (t) => {
         }
       ))
     })
-    assert.equal(expectedSdl1, composer.toSdl())
+    assert.strictEqual(expectedSdl1, composer.toSdl())
   }
 
   await services[0].instance.close()
 
   {
     const composer = await compose({
+      onSubgraphError: () => {},
       subgraphs: services.map(service => (
         {
           server: {
@@ -135,12 +137,13 @@ test('should handle partial subgraphs', async (t) => {
         }
       ))
     })
-    assert.equal(expectedSdl2, composer.toSdl())
+    assert.strictEqual(expectedSdl2, composer.toSdl())
   }
 })
 
 test('should handle all the unreachable subgraphs', async (t) => {
   const composer = await compose({
+    onSubgraphError: () => {},
     subgraphs: [
       {
         server: {
@@ -149,8 +152,8 @@ test('should handle all the unreachable subgraphs', async (t) => {
       }
     ]
   })
-  assert.equal('', composer.toSdl())
-  assert.deepEqual({}, composer.resolvers)
+  assert.strictEqual('', composer.toSdl())
+  assert.deepStrictEqual(Object.create(null), composer.resolvers)
 })
 
 test('should fire onSubgraphError retrieving subgraphs from unreachable services', async (t) => {
@@ -198,11 +201,11 @@ test('should fire onSubgraphError retrieving subgraphs from unreachable services
       }
     )),
     onSubgraphError: ({ error }) => {
-      assert.equal(expectedErrorMessage, error.message)
+      assert.strictEqual(expectedErrorMessage, error.message)
       errors++
     }
   })
 
-  assert.equal(errors, 2)
-  assert.equal(expectedSdl, composer.toSdl())
+  assert.strictEqual(errors, 2)
+  assert.strictEqual(expectedSdl, composer.toSdl())
 })

--- a/test/composer.js
+++ b/test/composer.js
@@ -49,7 +49,6 @@ test('should get sdl from composer', async (t) => {
   }
 
   const composer = await compose({
-    onSubgraphError: () => {},
     subgraphs: services.map(service => (
       {
         server: {
@@ -108,7 +107,6 @@ test('should handle partial subgraphs', async (t) => {
 
   {
     const composer = await compose({
-      onSubgraphError: () => {},
       subgraphs: services.map(service => (
         {
           server: {
@@ -126,7 +124,6 @@ test('should handle partial subgraphs', async (t) => {
 
   {
     const composer = await compose({
-      onSubgraphError: () => {},
       subgraphs: services.map(service => (
         {
           server: {
@@ -143,7 +140,6 @@ test('should handle partial subgraphs', async (t) => {
 
 test('should handle all the unreachable subgraphs', async (t) => {
   const composer = await compose({
-    onSubgraphError: () => {},
     subgraphs: [
       {
         server: {

--- a/test/helper.js
+++ b/test/helper.js
@@ -76,7 +76,6 @@ async function startRouter (t, subgraphs, overrides = {}) {
     }
   }
   const routerConfig = {
-    onSubgraphError: () => {},
     subgraphs: subgraphConfigs,
     subscriptions: { ...defaultSubscriptionHandler, ...overrides.subscriptions }
   }

--- a/test/helper.js
+++ b/test/helper.js
@@ -76,6 +76,7 @@ async function startRouter (t, subgraphs, overrides = {}) {
     }
   }
   const routerConfig = {
+    onSubgraphError: () => {},
     subgraphs: subgraphConfigs,
     subscriptions: { ...defaultSubscriptionHandler, ...overrides.subscriptions }
   }

--- a/test/helper.js
+++ b/test/helper.js
@@ -114,13 +114,16 @@ async function graphqlRequest (router, query, variables) {
   return data
 }
 
-async function startGraphqlService (t, options) {
-  const service = Fastify()
+async function startGraphqlService (t, { fastify, mercurius, exposeIntrospection = {} }) {
+  const service = Fastify(fastify ?? { logger: false })
 
-  service.register(Mercurius, options)
-  service.get('/graphql-composition', async function (req, reply) {
-    return reply.graphql(getIntrospectionQuery())
-  })
+  service.register(Mercurius, mercurius)
+
+  if (exposeIntrospection) {
+    service.get(exposeIntrospection.path || '/.well-known/graphql-composition', async function (req, reply) {
+      return reply.graphql(getIntrospectionQuery())
+    })
+  }
 
   t.after(async () => {
     try {

--- a/test/options.js
+++ b/test/options.js
@@ -27,6 +27,7 @@ test('should build a service using composer without subscriptions', async (t) =>
   const host = await service.listen()
 
   const composer = await compose({
+    onSubgraphError: () => {},
     subgraphs: [{ server: { host } }]
   })
 
@@ -43,5 +44,24 @@ test('should build a service using composer without subscriptions', async (t) =>
   const data = await graphqlRequest(router, query)
   assert.deepStrictEqual(data, { add: 4 })
 
-  assert.equal(calls, 1)
+  assert.strictEqual(calls, 1)
+})
+
+test('should get error without onSubgraphError function', async (t) => {
+  assert.rejects(compose({
+    subgraphs: [{ server: { host: 'http://graph1.local' } }]
+  }), {
+    name: 'TypeError',
+    message: ('onSubgraphError must be a function')
+  })
+})
+
+test('should get error with onSubgraphError not a function', async (t) => {
+  assert.rejects(compose({
+    subgraphs: [{ server: { host: 'http://graph1.local' } }],
+    onSubgraphError: 1
+  }), {
+    name: 'TypeError',
+    message: 'onSubgraphError must be a function'
+  })
 })

--- a/test/options.js
+++ b/test/options.js
@@ -27,7 +27,6 @@ test('should build a service using composer without subscriptions', async (t) =>
   const host = await service.listen()
 
   const composer = await compose({
-    onSubgraphError: () => {},
     subgraphs: [{ server: { host } }]
   })
 
@@ -47,17 +46,8 @@ test('should build a service using composer without subscriptions', async (t) =>
   assert.strictEqual(calls, 1)
 })
 
-test('should get error without onSubgraphError function', async (t) => {
-  assert.rejects(compose({
-    subgraphs: [{ server: { host: 'http://graph1.local' } }]
-  }), {
-    name: 'TypeError',
-    message: ('onSubgraphError must be a function')
-  })
-})
-
-test('should get error with onSubgraphError not a function', async (t) => {
-  assert.rejects(compose({
+test('should get error when onSubgraphError is not a function', async (t) => {
+  await assert.rejects(compose({
     subgraphs: [{ server: { host: 'http://graph1.local' } }],
     onSubgraphError: 1
   }), {


### PR DESCRIPTION
Change the behavior on fetching subgraph schema: instead of throwing an error, emit an event.

This allow to have partial schema from the defined ones