### PR TITLE
feat: add introspection fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ main()
       - `subgraphs` (array, optional) - Array of subgraph configuration objects with the following schema.
         - `server` (object, required) - Configuration object for communicating with the subgraph server with the following schema:
           - `host` (string, required) - The host information to connect to.
-          - `composeEndpoint` (string, optional) - The endpoint to retrieve the introspection query from. **Default:** `'/.well-known/graphql-composition'`.
+          - `composeEndpoint` (string, optional) - The endpoint to retrieve the introspection query from. **Default:** `'/.well-known/graphql-composition'`. In case the endpoint is not available, a second call with introspection query will be sent to the `graphqlEndpoint`.
           - `graphqlEndpoint` (string, optional) - The endpoint to make GraphQL queries against. **Default:** `'/graphql'`.
         - `entities` (object, optional) - Configuration object for working with entities in this subgraph. Each key in this object is the name of an entity data type. This is required if the subgraph contains any entities. The values are objects with the the following schema:
           - `adapter(partialResult)` (function, optional) - When resolving an entity across multiple subgraphs, an initial query is made to one subgraph followed by one or more followup queries to other subgraphs. The initial query must return enough information to identify the corresponding data in the other subgraphs. This function is invoked with the result of the initial query. It should return an object whose keys correspond to the `primaryKeyFields` configuration.

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -235,8 +235,7 @@ class Composer {
 
       if (status !== 'fulfilled') {
         const subgraph = this.#subgraphs[i]
-        const endpoint = `${subgraph.server.host}${subgraph.server.composeEndpoint}`
-        const msg = `Could not process schema from '${endpoint}'`
+        const msg = `Could not process schema from '${subgraph.server.host}'`
 
         this.onSubgraphError(new Error(msg, { cause: responses[i].reason }), { ...subgraph })
         continue

--- a/lib/network.js
+++ b/lib/network.js
@@ -1,14 +1,35 @@
 'use strict'
 const { request } = require('undici')
+const { getIntrospectionQuery } = require('graphql')
+const introspectionQuery = getIntrospectionQuery()
+
+function graphqlRequest ({ url, query, variables }) {
+  return request(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ query, variables })
+  })
+}
 
 async function fetchSubgraphSchema (server) {
-  const endpoint = `${server.host}${server.composeEndpoint}`
-  const response = await request(endpoint)
+  const composeEndpoint = `${server.host}${server.composeEndpoint}`
+  const endpoints = [composeEndpoint]
+  let response = await request(composeEndpoint)
 
   if (response.statusCode !== 200) {
-    const msg = `Subgraph responded with status code ${response.statusCode}`
+    // fallback to graphqlEndpoint sending introspection query
+    const graphqlEndpoint = `${server.host}${server.graphqlEndpoint}`
+    endpoints.push(graphqlEndpoint)
+    const gqlResponse = await graphqlRequest({ url: graphqlEndpoint, query: introspectionQuery })
 
-    throw new Error(msg)
+    if (gqlResponse.statusCode !== 200) {
+      const msg = `Unable to get schema from ${composeEndpoint} (response ${gqlResponse.statusCode}) nor ${graphqlEndpoint} (response ${gqlResponse.statusCode})`
+      throw new Error(msg)
+    }
+
+    response = gqlResponse
   }
 
   let introspection
@@ -22,7 +43,7 @@ async function fetchSubgraphSchema (server) {
 
     introspection = res.data
   } catch (err) {
-    const msg = `Invalid introspection schema received from '${endpoint}'`
+    const msg = `Invalid introspection schema received from ${endpoints.join(', ')}`
 
     throw new Error(msg, { cause: err })
   }

--- a/test/composer.js
+++ b/test/composer.js
@@ -129,7 +129,8 @@ test('should handle partial subgraphs', async (t) => {
     let errors = 0
     const composer = await compose({
       onSubgraphError: (error) => {
-        assert.strictEqual(error.message, `Could not process schema from '${services[0].host}/get-introspection'`)
+        assert.strictEqual(error.message, `Could not process schema from '${services[0].host}'`)
+        assert.match(error.cause.message, /connect ECONNREFUSED/)
         errors++
       },
       subgraphs: services.map(service => (
@@ -152,7 +153,159 @@ test('should handle all the unreachable subgraphs', async (t) => {
 
   const composer = await compose({
     onSubgraphError: (error) => {
-      assert.strictEqual(error.message, "Could not process schema from 'http://unreachable.local/.well-known/graphql-composition'")
+      assert.strictEqual(error.message, "Could not process schema from 'http://unreachable.local'")
+      assert.match(error.cause.message, /getaddrinfo (ENOTFOUND|EAI_AGAIN) unreachable.local/)
+      errors++
+    },
+    subgraphs: [
+      {
+        server: {
+          host: 'http://unreachable.local'
+        }
+      }
+    ]
+  })
+
+  assert.strictEqual(errors, 1)
+  assert.strictEqual('', composer.toSdl())
+  assert.deepStrictEqual(Object.create(null), composer.resolvers)
+})
+
+test('should fire onSubgraphError retrieving subgraphs from unreachable services', async (t) => {
+  const services = [
+    {
+      off: true,
+      schema: 'type Query { add(x: Int, y: Int): Int }',
+      resolvers: { Query: { add: (_, { x, y }) => x + y } }
+    },
+    {
+      off: true,
+      schema: 'type Query { mul(a: Int, b: Int): Int }',
+      resolvers: { Query: { mul: (_, { a, b }) => a * b } }
+    },
+    {
+      schema: 'type Query { sub(x: Int, y: Int): Int }',
+      resolvers: { Query: { sub: (_, { x, y }) => x - y } }
+    }]
+  const expectedSdl = 'type Query {\n' +
+    '  sub(x: Int, y: Int): Int\n' +
+    '}'
+
+  for (const service of services) {
+    if (service.off) {
+      service.host = 'http://unreachable.local'
+      continue
+    }
+    service.instance = await startGraphqlService(t, {
+      mercurius: {
+        schema: service.schema,
+        resolvers: service.resolvers
+      }
+    })
+    service.host = await service.instance.listen()
+  }
+
+  let errors = 0
+  const composer = await compose({
+    onSubgraphError: () => { errors++ },
+    subgraphs: services.map(service => (
+      {
+        server: {
+          host: service.host
+        }
+      }
+    ))
+  })
+
+  assert.strictEqual(errors, 2)
+  assert.strictEqual(expectedSdl, composer.toSdl())
+})
+
+test('should handle partial subgraphs', async (t) => {
+  const services = [
+    {
+      schema: 'type Query { add(x: Int, y: Int): Int }',
+      resolvers: { Query: { add: (_, { x, y }) => x + y } }
+    },
+    {
+      schema: 'type Query { mul(a: Int, b: Int): Int }',
+      resolvers: { Query: { mul: (_, { a, b }) => a * b } }
+    },
+    {
+      schema: 'type Query { sub(x: Int, y: Int): Int }',
+      resolvers: { Query: { sub: (_, { x, y }) => x - y } }
+    }]
+
+  for (const service of services) {
+    service.instance = await startGraphqlService(t, {
+      mercurius: {
+        schema: service.schema,
+        resolvers: service.resolvers
+      },
+      exposeIntrospection: {
+        path: '/get-introspection'
+      }
+    })
+    service.host = await service.instance.listen()
+  }
+  const expectedSdl1 = 'type Query {\n' +
+    '  add(x: Int, y: Int): Int\n' +
+    '  mul(a: Int, b: Int): Int\n' +
+    '  sub(x: Int, y: Int): Int\n' +
+    '}'
+  const expectedSdl2 = 'type Query {\n' +
+    '  mul(a: Int, b: Int): Int\n' +
+    '  sub(x: Int, y: Int): Int\n' +
+    '}'
+
+  {
+    let errors = 0
+    const composer = await compose({
+      onSubgraphError: () => { errors++ },
+      subgraphs: services.map(service => (
+        {
+          server: {
+            host: service.host,
+            composeEndpoint: '/get-introspection',
+            graphqlEndpoint: '/graphql'
+          }
+        }
+      ))
+    })
+    assert.strictEqual(errors, 0)
+    assert.strictEqual(expectedSdl1, composer.toSdl())
+  }
+
+  await services[0].instance.close()
+
+  {
+    let errors = 0
+    const composer = await compose({
+      onSubgraphError: (error) => {
+        assert.strictEqual(error.message, `Could not process schema from '${services[0].host}'`)
+        errors++
+      },
+      subgraphs: services.map(service => (
+        {
+          server: {
+            host: service.host,
+            composeEndpoint: '/get-introspection',
+            graphqlEndpoint: '/graphql'
+          }
+        }
+      ))
+    })
+    assert.strictEqual(errors, 1)
+    assert.strictEqual(expectedSdl2, composer.toSdl())
+  }
+})
+
+test('should handle all the unreachable subgraphs', async (t) => {
+  let errors = 0
+
+  const composer = await compose({
+    onSubgraphError: (error) => {
+      assert.strictEqual(error.message, "Could not process schema from 'http://unreachable.local'")
       errors++
     },
     subgraphs: [

--- a/test/network.js
+++ b/test/network.js
@@ -1,0 +1,126 @@
+'use strict'
+
+const assert = require('node:assert')
+const { test } = require('node:test')
+const { NoSchemaIntrospectionCustomRule } = require('graphql')
+
+const { compose } = require('../lib')
+const { startGraphqlService } = require('./helper')
+
+const service = {
+  schema: 'type Query {\n  add(x: Int, y: Int): Int\n}',
+  resolvers: { Query: { add: (_, { x, y }) => x + y } }
+}
+
+test('should get the schema from a subgraph service from composeEndpoint', async (t) => {
+  const expectedSdl = service.schema
+
+  const instance = await startGraphqlService(t, {
+    mercurius: {
+      schema: service.schema,
+      resolvers: service.resolvers
+    },
+    exposeIntrospection: {
+      path: '/get-introspection'
+    }
+  })
+  service.host = await instance.listen()
+
+  let errors = 0
+  const composer = await compose({
+    onSubgraphError: () => { errors++ },
+    subgraphs: [
+      {
+        server: {
+          host: service.host,
+          composeEndpoint: '/get-introspection',
+          graphqlEndpoint: '/graphql'
+        }
+      }
+    ]
+  })
+
+  assert.strictEqual(errors, 0)
+  assert.strictEqual(composer.toSdl(), expectedSdl)
+})
+
+test('should get the schema from a subgraph service from graphqlEndpoint using introspection query', async (t) => {
+  const expectedSdl = service.schema
+
+  const instance = await startGraphqlService(t, {
+    mercurius: {
+      schema: service.schema,
+      resolvers: service.resolvers
+    },
+    exposeIntrospection: false
+  })
+  service.host = await instance.listen()
+
+  let errors = 0
+  const composer = await compose({
+    onSubgraphError: () => { errors++ },
+    subgraphs: [
+      {
+        server: {
+          host: service.host,
+          graphqlEndpoint: '/graphql'
+        }
+      }
+    ]
+  })
+
+  assert.strictEqual(errors, 0)
+  assert.strictEqual(composer.toSdl(), expectedSdl)
+})
+
+test('should get error when is not possible to get the schema from a subgraph neither from composeEndpoint and using introspection query', async (t) => {
+  const instance = await startGraphqlService(t, {
+    mercurius: {
+      schema: service.schema,
+      resolvers: service.resolvers,
+      validationRules: [NoSchemaIntrospectionCustomRule]
+    },
+    exposeIntrospection: false
+  })
+  service.host = await instance.listen()
+
+  let errors = 0
+  await compose({
+    onSubgraphError: (error) => {
+      const expectedErrorMessage = `Could not process schema from '${service.host}'`
+      const expectedErrorCauseMessage = `Invalid introspection schema received from ${service.host}/custom-compose, ${service.host}/graphql`
+      assert.strictEqual(error.message, expectedErrorMessage)
+      assert.strictEqual(error.cause.message, expectedErrorCauseMessage)
+      errors++
+    },
+    subgraphs: [{ server: { host: service.host, composeEndpoint: '/custom-compose' } }]
+  })
+
+  assert.strictEqual(errors, 1)
+})
+
+test('should get error when composeEndpoint and graphqlEndpoint are both unreachable', async (t) => {
+  const instance = await startGraphqlService(t, {
+    mercurius: {
+      schema: service.schema,
+      resolvers: service.resolvers,
+      path: '/graph-custom-path'
+    },
+    exposeIntrospection: false
+  })
+  service.host = await instance.listen()
+
+  let errors = 0
+  await compose({
+    onSubgraphError: (error) => {
+      const expectedErrorMessage = `Could not process schema from '${service.host}'`
+      const expectedErrorCauseMessage = `Unable to get schema from ${service.host}/.well-known/graphql-composition (response 404) nor ${service.host}/graphql (response 404)`
+      assert.strictEqual(error.message, expectedErrorMessage)
+      assert.strictEqual(error.cause.message, expectedErrorCauseMessage)
+      errors++
+    },
+    subgraphs: [{ server: { host: service.host } }]
+  })
+
+  assert.strictEqual(errors, 1)
+})


### PR DESCRIPTION
Fetching subgraph schema, perform a fallback request to `graphqlEndpoint` sending introspection `query`