### PR TITLE
fix: unwrapFieldTypeName

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -73,7 +73,7 @@ function pathJoin (...args) {
 // -- gql utilities
 
 function unwrapFieldTypeName (field) {
-  return field.type.name || field.type.ofType.name || field.type.ofType.ofType.name
+  return field.type.name || unwrapFieldTypeName({ type: field.type.ofType })
 }
 
 function collectPlainArgs (args, nodeArguments, info) {

--- a/test/entities/on-subgraphs-2.test.js
+++ b/test/entities/on-subgraphs-2.test.js
@@ -27,7 +27,7 @@ const booksSubgraph = () => {
   type Query {
     getBook(id: ID!): Book
     getBookTitle(id: ID!): String
-    getBooksByIds(ids: [ID]!): [Book]!
+    getBooksByIds(ids: [ID]!): [Book!]!
   }
 `
   const data = { library: null }


### PR DESCRIPTION
In some cases, the `unwrapFieldTypeName` function returned `null` because an object was too nested. 
This resulted in a `TypeError [Error]: Cannot read properties of undefined`.

I have adapted the tests to demonstrate this by simply having a `[Book!]!` return type. 
In the example, the field object looks like this:

```
{
  "kind": "NON_NULL",
  "name": null,
  "ofType": {
    "kind": "LIST",
    "name": null,
    "ofType": {
      "kind": "NON_NULL",
      "name": null,
      "ofType": {
        "kind": "OBJECT",
        "name": "Book",
        "ofType": null
      }
    }
  }
}
```

The previous approach would return `field.type.ofType.ofType.name`, which is still `null` instead of the desired `Book` type. In order to fix this, I made the `unwrapFieldTypeName` function work recursively.