### PR TITLE
fix: handle enum and scalar input variables

### DIFF
--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -274,7 +274,10 @@ function buildNodeQueryArgs (args, root = true) {
   }
 
   // TODO test: quotes
-  return args.type !== 'StringValue' ? args.value.toString() : `"${args.value}"`
+  if (args.value === null) {
+    return null
+  }
+  return args.type !== 'StringValue' ? args.value?.toString() : `"${args.value}"`
 }
 
 function buildPlainQueryArgs (v, root = true) {

--- a/lib/query-lookup.js
+++ b/lib/query-lookup.js
@@ -57,7 +57,7 @@ function collectQueries ({
         operation: context.info ? context.info.operation.operation : '',
         resolver: resolver ?? { name: resolverName },
         selection: [],
-        args: collectPlainArgs(args, queryFieldNode.arguments, context.info)
+        args: collectPlainArgs(args, queryFieldNode.arguments, context.info, types)
       })
     })
     const querySelection = queryFieldNode
@@ -93,7 +93,7 @@ function collectQueries ({
       // TODO createResolver fn
       resolver: resolver ?? { name: resolverName },
       selection: [],
-      args: collectPlainArgs(args, queryFieldNode.arguments, context.info)
+      args: collectPlainArgs(args, queryFieldNode.arguments, context.info, types)
     })
   })
 

--- a/lib/query-lookup.js
+++ b/lib/query-lookup.js
@@ -270,7 +270,7 @@ function collectNestedQueries ({
     parent: queryNode,
     path,
     fieldId,
-    args: collectNodeArgs(querySelection.arguments, context.info),
+    args: collectNodeArgs(querySelection.arguments, context.info, types),
     types,
     fields,
     aliases,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,19 +78,19 @@ function unwrapFieldTypeName (field) {
   return field.type.name || unwrapFieldTypeName({ type: field.type.ofType })
 }
 
-function collectPlainArgs (args, nodeArguments, info) {
+function collectPlainArgs (args, nodeArguments, info, types) {
   if (args === undefined || args === null) {
     return
   }
 
   if (nodeArguments?.kind === 'Variable') {
-    return collectVariableArg(nodeArguments, info)
+    return collectVariableArg(nodeArguments, info, types)
   }
 
   if (Array.isArray(args)) {
     const queryArgs = []
     for (let i = 0; i < args.length; i++) {
-      const arg = collectPlainArgs(args[i], nodeArguments[i], info)
+      const arg = collectPlainArgs(args[i], nodeArguments[i], info, types)
       if (!arg) {
         continue
       }
@@ -106,7 +106,7 @@ function collectPlainArgs (args, nodeArguments, info) {
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i]
       const node = selectArgNode(nodeArguments, key)
-      const value = collectPlainArgs(args[key], node, info)
+      const value = collectPlainArgs(args[key], node, info, types)
       if (!value) {
         continue
       }
@@ -179,47 +179,94 @@ function collectNodeArgs (nodeArguments, info) {
   return args
 }
 
-function unwrapArrayVariable (varValue) {
+function unwrapArrayVariable (varValue, varTypes) {
   const value = []
   for (let j = 0; j < varValue.length; j++) {
     const v = varValue[j]
-    value.push(unwrapVariable(v))
+    value.push(unwrapVariable(v, varTypes ? varTypes[0] : undefined))
   }
   return { value, type: 'ListValue' }
 }
 
-function unwrapObjectVariable (varValue) {
+function unwrapObjectVariable (varValue, varTypes) {
   const value = {}
   const keys = Object.keys(varValue)
   for (let j = 0; j < keys.length; j++) {
     const v = varValue[keys[j]]
-    value[keys[j]] = unwrapVariable(v)
+    value[keys[j]] = unwrapVariable(
+      v,
+      varTypes ? varTypes[keys[j]] : undefined
+    )
   }
   return { value, type: 'ObjectValue' }
 }
 
-function unwrapVariable (varValue) {
+function unwrapVariable (varValue, varTypes) {
   if (Array.isArray(varValue)) {
-    return unwrapArrayVariable(varValue)
+    return unwrapArrayVariable(varValue, varTypes)
   }
   if (typeof varValue === 'object') {
-    return unwrapObjectVariable(varValue)
+    return unwrapObjectVariable(varValue, varTypes)
   }
-  return { value: varValue, type: mapJsToGqlType(varValue) }
+  return { value: varValue, type: mapJsToGqlType(varValue, varTypes) }
 }
 
-function collectVariableArg (node, info) {
+function collectVariableArg (node, info, type) {
   const varName = node.name.value
   const varValue = info.variableValues[varName]
-  return unwrapVariable(varValue)
+  const varTypes = resolveVariableType(varName, varValue, info, type)
+  return unwrapVariable(varValue, varTypes)
 }
 
 const _mapJsToGqlType = {
-  string: 'StringValue'
+  string: 'StringValue',
+  number: 'IntValue'
 }
 
-function mapJsToGqlType (value) {
-  return _mapJsToGqlType[typeof value]
+function mapJsToGqlType (value, varTypes) {
+  return varTypes || _mapJsToGqlType[typeof value]
+}
+
+// -- schema utilities
+
+function resolveVariableType (varName, varValue, info, types) {
+  const variableDefinition = info.operation.variableDefinitions.find(
+    (v) => v.variable.name.value === varName
+  )
+  const type = variableDefinition?.type?.type?.name?.value
+  return mapInputTypeToTypes(type, types)
+}
+
+function mapInputTypeToTypes (inputTypeName, types) {
+  if (!types || !inputTypeName || !types[inputTypeName]) {
+    return undefined
+  }
+
+  function mapType (type) {
+    if (type.kind === 'SCALAR') {
+      return 'StringValue'
+    } else if (type.kind === 'ENUM') {
+      return 'EnumValue'
+    } else if (type.kind === 'INPUT_OBJECT') {
+      return mapInputTypeToTypes(type.name, types)
+    } else if (type.kind === 'LIST') {
+      return [mapType(type.ofType)]
+    } else if (type.kind === 'NON_NULL') {
+      return mapType(type.ofType)
+    }
+    return null
+  }
+
+  const inputType = types[inputTypeName]
+  const result = {}
+
+  if (inputType.src.inputFields) {
+    inputType.src.inputFields.forEach((field) => {
+      result[field.name] = mapType(field.type)
+    })
+  }
+
+  return result
 }
 
 function schemaTypeName (types, subgraphName, entityName, fieldName) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -91,9 +91,7 @@ function collectPlainArgs (args, nodeArguments, info, types) {
     const queryArgs = []
     for (let i = 0; i < args.length; i++) {
       const arg = collectPlainArgs(args[i], nodeArguments[i], info, types)
-      if (!arg) {
-        continue
-      }
+      if (!arg) { continue }
       queryArgs.push(arg)
     }
 
@@ -107,9 +105,7 @@ function collectPlainArgs (args, nodeArguments, info, types) {
       const key = keys[i]
       const node = selectArgNode(nodeArguments, key)
       const value = collectPlainArgs(args[key], node, info, types)
-      if (!value) {
-        continue
-      }
+      if (!value) { continue }
       queryArgs[key] = value
     }
 
@@ -162,7 +158,7 @@ function selectArgNode (nodeArguments, key) {
   return value
 }
 
-function collectNodeArgs (nodeArguments, info) {
+function collectNodeArgs (nodeArguments, info, types) {
   if (!nodeArguments || nodeArguments.length < 1) {
     return {}
   }
@@ -174,7 +170,7 @@ function collectNodeArgs (nodeArguments, info) {
       args[name] = node.value.value
       continue
     }
-    args[name] = collectVariableArg(node.value, info)
+    args[name] = collectVariableArg(node.value, info, types)
   }
   return args
 }
@@ -224,12 +220,32 @@ function mapJsToGqlType (value, varTypes) {
   return varTypes || _mapJsToGqlType[typeof value]
 }
 
+function findNamedType (obj) {
+  if (obj === null || typeof obj !== 'object') {
+    return null
+  }
+  if (obj.kind === 'NamedType') {
+    return obj.name.value
+  } else if (obj.type) {
+    return findNamedType(obj.type)
+  }
+  return null
+}
+
 function resolveVariableType (varName, varValue, info, types) {
-  const variableDefinition = info.operation.variableDefinitions.find(
-    (v) => v.variable.name.value === varName
+  const variableDefinition = info.operation.variableDefinitions?.find(
+    (v) => v.variable?.name?.value === varName
   )
-  const type = variableDefinition.type.type.name.value
+  const type = findNamedType(variableDefinition)
   return mapInputTypeToTypes(type, types)
+}
+
+const scalarTypes = {
+  ID: 'StringValue',
+  String: 'StringValue',
+  Int: 'IntValue',
+  Float: 'FloatValue',
+  Boolean: 'BooleanValue'
 }
 
 function mapType (type, types) {
@@ -255,23 +271,24 @@ function mapInputTypeToTypes (inputTypeName, types) {
   }
 
   const inputType = types[inputTypeName]
-  const result = {}
-
-  if (inputType.src.inputFields) {
-    inputType.src.inputFields.forEach((field) => {
-      result[field.name] = mapType(field.type, types)
-    })
+  switch (inputType?.src?.kind) {
+    case 'INPUT_OBJECT':
+      return inputType.src.inputFields.reduce((result, field) => {
+        result[field.name] = mapType(field.type, types)
+        return result
+      }, {})
+    case 'OBJECT':
+      return inputType.src.fields.reduce((result, field) => {
+        result[field.name] = mapType(field.type, types)
+        return result
+      }, {})
+    case 'SCALAR':
+      return scalarTypes[inputType.src.name]
+    case 'ENUM':
+      return 'EnumValue'
+    default:
+      return undefined
   }
-
-  return result
-}
-
-const scalarTypes = {
-  ID: 'StringValue',
-  String: 'StringValue',
-  Int: 'IntValue',
-  Float: 'FloatValue',
-  Boolean: 'BooleanValue'
 }
 
 function schemaTypeName (types, subgraphName, entityName, fieldName) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -198,7 +198,7 @@ function unwrapVariable (varValue, varTypes) {
   if (Array.isArray(varValue)) {
     return unwrapArrayVariable(varValue, varTypes)
   }
-  if (typeof varValue === 'object') {
+  if (varValue !== null && typeof varValue === 'object') {
     return unwrapObjectVariable(varValue, varTypes)
   }
   return { value: varValue, type: mapJsToGqlType(varValue, varTypes) }
@@ -271,7 +271,7 @@ function mapInputTypeToTypes (inputTypeName, types) {
   }
 
   const inputType = types[inputTypeName]
-  switch (inputType?.src?.kind) {
+  switch (inputType.src?.kind) {
     case 'INPUT_OBJECT':
       return inputType.src.inputFields.reduce((result, field) => {
         result[field.name] = mapType(field.type, types)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -183,7 +183,7 @@ function unwrapArrayVariable (varValue, varTypes) {
   const value = []
   for (let j = 0; j < varValue.length; j++) {
     const v = varValue[j]
-    value.push(unwrapVariable(v, varTypes ? varTypes[0] : undefined))
+    value.push(unwrapVariable(v, varTypes))
   }
   return { value, type: 'ListValue' }
 }
@@ -193,10 +193,7 @@ function unwrapObjectVariable (varValue, varTypes) {
   const keys = Object.keys(varValue)
   for (let j = 0; j < keys.length; j++) {
     const v = varValue[keys[j]]
-    value[keys[j]] = unwrapVariable(
-      v,
-      varTypes ? varTypes[keys[j]] : undefined
-    )
+    value[keys[j]] = unwrapVariable(v, varTypes ? varTypes[keys[j]] : undefined)
   }
   return { value, type: 'ObjectValue' }
 }
@@ -211,10 +208,10 @@ function unwrapVariable (varValue, varTypes) {
   return { value: varValue, type: mapJsToGqlType(varValue, varTypes) }
 }
 
-function collectVariableArg (node, info, type) {
+function collectVariableArg (node, info, types) {
   const varName = node.name.value
   const varValue = info.variableValues[varName]
-  const varTypes = resolveVariableType(varName, varValue, info, type)
+  const varTypes = resolveVariableType(varName, varValue, info, types)
   return unwrapVariable(varValue, varTypes)
 }
 
@@ -227,14 +224,29 @@ function mapJsToGqlType (value, varTypes) {
   return varTypes || _mapJsToGqlType[typeof value]
 }
 
-// -- schema utilities
-
 function resolveVariableType (varName, varValue, info, types) {
   const variableDefinition = info.operation.variableDefinitions.find(
     (v) => v.variable.name.value === varName
   )
-  const type = variableDefinition?.type?.type?.name?.value
+  const type = variableDefinition.type.type.name.value
   return mapInputTypeToTypes(type, types)
+}
+
+function mapType (type, types) {
+  switch (type.kind) {
+    case 'SCALAR':
+      return scalarTypes[type.name]
+    case 'ENUM':
+      return 'EnumValue'
+    case 'INPUT_OBJECT':
+      return mapInputTypeToTypes(type.name, types)
+    case 'LIST':
+      return mapType(type.ofType, types)
+    case 'NON_NULL':
+      return mapType(type.ofType, types)
+    default:
+      return undefined
+  }
 }
 
 function mapInputTypeToTypes (inputTypeName, types) {
@@ -242,31 +254,24 @@ function mapInputTypeToTypes (inputTypeName, types) {
     return undefined
   }
 
-  function mapType (type) {
-    if (type.kind === 'SCALAR') {
-      return 'StringValue'
-    } else if (type.kind === 'ENUM') {
-      return 'EnumValue'
-    } else if (type.kind === 'INPUT_OBJECT') {
-      return mapInputTypeToTypes(type.name, types)
-    } else if (type.kind === 'LIST') {
-      return [mapType(type.ofType)]
-    } else if (type.kind === 'NON_NULL') {
-      return mapType(type.ofType)
-    }
-    return null
-  }
-
   const inputType = types[inputTypeName]
   const result = {}
 
   if (inputType.src.inputFields) {
     inputType.src.inputFields.forEach((field) => {
-      result[field.name] = mapType(field.type)
+      result[field.name] = mapType(field.type, types)
     })
   }
 
   return result
+}
+
+const scalarTypes = {
+  ID: 'StringValue',
+  String: 'StringValue',
+  Int: 'IntValue',
+  Float: 'FloatValue',
+  Boolean: 'BooleanValue'
 }
 
 function schemaTypeName (types, subgraphName, entityName, fieldName) {

--- a/test/fixtures/authors.js
+++ b/test/fixtures/authors.js
@@ -145,7 +145,7 @@ const resolvers = {
         }
       })
 
-      return true
+      return { success: true }
     }
   },
   Author: {

--- a/test/fixtures/authors.js
+++ b/test/fixtures/authors.js
@@ -17,8 +17,9 @@ const schema = `
   input AuthorAddressInput {
     street: String!
     city: String!
-    zip: String!
+    zip: Int!
     country: Country!
+    public: Boolean!
   }
   
   input AuthorInput {

--- a/test/fixtures/authors.js
+++ b/test/fixtures/authors.js
@@ -19,7 +19,7 @@ const schema = `
     city: String!
     zip: Int!
     country: Country!
-    public: Boolean!
+    mainResidence: Boolean!
   }
   
   input AuthorInput {

--- a/test/fixtures/authors.js
+++ b/test/fixtures/authors.js
@@ -5,10 +5,20 @@ const schema = `
     task: String
   }
 
+  enum Country {
+    US
+    CA
+    UK
+    DE
+    FR
+    ES
+  }
+
   input AuthorAddressInput {
     street: String!
     city: String!
     zip: String!
+    country: Country!
   }
   
   input AuthorInput {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -456,7 +456,8 @@ test('mutations', async (t) => {
           address: {
             street: 'Johnson Street 5',
             city: 'Johnson City',
-            zip: '4200'
+            zip: '4200',
+            country: 'US'
           },
           todos: [
             { task: 'Write another book' },

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -475,6 +475,31 @@ test('mutations', async (t) => {
     },
 
     {
+      name: 'should run a mutation query with nested variables including null values',
+      query: `
+      mutation CreateAuthor($author: AuthorInput!) {
+        createAuthor(author: $author) {
+          id name { firstName lastName }
+        }
+      }
+      `,
+      variables: {
+        author: {
+          firstName: 'John',
+          lastName: 'Johnson',
+          address: null,
+          todos: []
+        }
+      },
+      result: {
+        createAuthor: {
+          id: '3',
+          name: { firstName: 'John', lastName: 'Johnson' }
+        }
+      }
+    },
+
+    {
       name: 'should run a mutation query with input object literal',
       query: `
       mutation {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -456,8 +456,9 @@ test('mutations', async (t) => {
           address: {
             street: 'Johnson Street 5',
             city: 'Johnson City',
-            zip: '4200',
-            country: 'US'
+            zip: 4200,
+            country: 'US',
+            public: true
           },
           todos: [
             { task: 'Write another book' },

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -515,6 +515,35 @@ test('mutations', async (t) => {
           }
         ]
       }
+    },
+
+    {
+      name: 'should run a mutation query with an array as input variable',
+      query: `
+      mutation BatchCreateAuthor($authors: [AuthorInput]!) {
+        batchCreateAuthor(authors: $authors) {
+          id name { firstName lastName }
+        }
+      }
+      `,
+      variables: {
+        authors: [
+          { firstName: 'Ernesto', lastName: 'de la Cruz' },
+          { firstName: 'Hector', lastName: 'Rivera' }
+        ]
+      },
+      result: {
+        batchCreateAuthor: [
+          {
+            id: '3',
+            name: { firstName: 'Ernesto', lastName: 'de la Cruz' }
+          },
+          {
+            id: '4',
+            name: { firstName: 'Hector', lastName: 'Rivera' }
+          }
+        ]
+      }
     }
   ]
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -458,7 +458,7 @@ test('mutations', async (t) => {
             city: 'Johnson City',
             zip: 4200,
             country: 'US',
-            public: true
+            mainResidence: true
           },
           todos: [
             { task: 'Write another book' },


### PR DESCRIPTION
This PR fixes the issue mentioned in [#3046](https://github.com/platformatic/platformatic/issues/3046).

First we needed to take the actual GraphQl types of the input variables into account when calling `collectQueries`. So `collectVariableArg` now also expects the type definitions so that we later can get the type of the input variable - if this is an object we traverse through all `inputFields` recursively to get the individual types of the properties. When calling `unwrapVariable` the collected type map is then passed alongside so that we can get the actual type of the value and return it.

In the query builder we needed to make a small adjustment as well to also handle `null` values.

Please let us know what you guys think of this solution.