### PR TITLE
fix: handle errors thrown in subgraph

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -60,8 +60,14 @@ async function makeGraphqlRequest ({ server, headers, query }) {
     query
   })
 
-  const { data, errors } = await gqlResponse.body.json()
+  const res = await gqlResponse.body.json()
+  // check if exception was thrown by the subgraph
+  if (res.error) {
+    const msg = res.message ?? res.error ?? 'Unknown subgraph request error'
+    throw new Error(msg, { cause: res })
+  }
 
+  const { data, errors } = res
   if (errors) {
     const msg = errors?.[0]?.message ?? 'Unknown subgraph request error'
     throw new Error(msg, { cause: errors })

--- a/test/network.test.js
+++ b/test/network.test.js
@@ -179,8 +179,7 @@ test('makeGraphqlRequest should throw an error if the subgraph context returns a
         ...gql,
         context: () => {
           throw new Error('Error in context')
-        },
-        validationRules: [NoSchemaIntrospectionCustomRule]
+        }
       },
       exposeIntrospection: false,
       listen: true

--- a/test/network.test.js
+++ b/test/network.test.js
@@ -6,6 +6,7 @@ const { NoSchemaIntrospectionCustomRule } = require('graphql')
 
 const { compose } = require('../')
 const { createGraphqlServices } = require('./helper')
+const { makeGraphqlRequest } = require('../lib/network')
 
 const gql = {
   schema: 'type Query {\n  add(x: Int, y: Int): Int\n}',
@@ -106,4 +107,117 @@ test('should get error when composeEndpoint and graphqlEndpoint are both unreach
   })
 
   assert.strictEqual(errors, 1)
+})
+
+test('makeGraphqlRequest should return data for a valid query', async (t) => {
+  const [service] = await createGraphqlServices(t,
+    [{
+      mercurius: { ...gql },
+      exposeIntrospection: false,
+      listen: true
+    }]
+  )
+
+  const query = '{ add(x: 1, y: 2) }'
+  const data = await makeGraphqlRequest({
+    server: { host: service.host, graphqlEndpoint: '/graphql' },
+    headers: {},
+    query
+  })
+
+  assert.deepStrictEqual(data, { add: 3 })
+})
+
+test('makeGraphqlRequest should throw an error for a query with errors', async (t) => {
+  const [service] = await createGraphqlServices(t,
+    [{
+      mercurius: { ...gql },
+      exposeIntrospection: false,
+      listen: true
+    }]
+  )
+
+  const query = '{ subtract(x: 1, y: 2) }' // Invalid query
+  await assert.rejects(
+    makeGraphqlRequest({
+      server: { host: service.host, graphqlEndpoint: '/graphql' },
+      headers: {},
+      query
+    }),
+    {
+      message: 'Cannot query field "subtract" on type "Query".'
+    }
+  )
+})
+
+test('makeGraphqlRequest should throw an error if the subgraph returns an error', async (t) => {
+  const [service] = await createGraphqlServices(t,
+    [{
+      mercurius: { ...gql, validationRules: [NoSchemaIntrospectionCustomRule] },
+      exposeIntrospection: false,
+      listen: true
+    }]
+  )
+
+  const query = '{ __schema { queryType { name } } }'
+  await assert.rejects(
+    makeGraphqlRequest({
+      server: { host: service.host, graphqlEndpoint: '/graphql' },
+      headers: {},
+      query
+    }),
+    {
+      message: 'GraphQL introspection has been disabled, but the requested query contained the field "__schema".'
+    }
+  )
+})
+
+test('makeGraphqlRequest should throw an error if the subgraph context returns an error', async (t) => {
+  const [service] = await createGraphqlServices(t,
+    [{
+      mercurius: {
+        ...gql,
+        context: () => {
+          throw new Error('Error in context')
+        },
+        validationRules: [NoSchemaIntrospectionCustomRule]
+      },
+      exposeIntrospection: false,
+      listen: true
+    }]
+  )
+
+  const query = '{ add(x: 1, y: 2) }'
+  await assert.rejects(
+    makeGraphqlRequest({
+      server: { host: service.host, graphqlEndpoint: '/graphql' },
+      headers: {},
+      query
+    }),
+    {
+      message: 'Error in context'
+    }
+  )
+})
+
+test('makeGraphqlRequest should throw an error if the response contains an error', async (t) => {
+  const [service] = await createGraphqlServices(t,
+    [{
+      mercurius: { ...gql },
+      exposeIntrospection: false,
+      listen: true
+    }]
+  )
+
+  const query = '{ add(x: 1, y: "two") }' // Invalid argument type
+  await assert.rejects(
+    makeGraphqlRequest({
+      server: { host: service.host, graphqlEndpoint: '/graphql' },
+      headers: {},
+      query
+    }),
+    {
+      message: 'Int cannot represent non-integer value: "two"'
+    }
+  )
 })


### PR DESCRIPTION
When an exception was thrown in a graphql endpoint (not an exception in GraphQl but before, e.g. the context) the graphql composer was not able to handle this properly. It was just checking if `errors` was set in the response and if it was not present tried to access the subgraph response from `data` which was not returned in the case of an exception thrown before. This resulted in a `Cannot read properties of undefined` error. To avoid this we now check if `error` is present in the response and throw an error in that case.