### PR TITLE
Fix: graphql composer nested objects

### DIFF
--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -134,10 +134,9 @@ function buildQuerySelection (selection, parent, wrap = true, fragment = undefin
     } else if (selection[i].selection) {
       fields.add(buildQuerySelection(selection[i].selection, null, selection[i].wrap, selection[i].fragment).selection)
     } else if (selection[i].nested) {
-      fields.add(selection[i].parentField)
       for (const nested of selection[i].nested.values()) {
         const s = buildSubQuery(nested.query, nested)
-        fields.add(s.subquery)
+        fields.add(`${selection[i].parentField} ${s.subquery}`)
         for (const i of Object.keys(s.keys)) {
           const k = s.keys[i]
           keys.set(k.resolverPath + keyId(k), k)

--- a/test/fixtures/books.js
+++ b/test/fixtures/books.js
@@ -5,10 +5,17 @@ const schema = `
     NONFICTION
   }
 
+  type ChapterData {
+    title: String
+    pageCount: Int
+  }
+
   type Book {
     id: ID!
     title: String
     genre: BookGenre
+    firstChapter: ChapterData
+    lastChapter: ChapterData
   }
 
   enum BookField {
@@ -38,12 +45,28 @@ function reset () {
     1: {
       id: 1,
       title: 'A Book About Things That Never Happened',
-      genre: 'FICTION'
+      genre: 'FICTION',
+      firstChapter: {
+        title: 'The Beginning',
+        pageCount: 20
+      },
+      lastChapter: {
+        title: 'The End',
+        pageCount: 25
+      }
     },
     2: {
       id: 2,
       title: 'A Book About Things That Really Happened',
-      genre: 'NONFICTION'
+      genre: 'NONFICTION',
+      firstChapter: {
+        title: 'Introduction',
+        pageCount: 15
+      },
+      lastChapter: {
+        title: 'Conclusion',
+        pageCount: 18
+      }
     }
   }
 }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -669,6 +669,34 @@ test('mutations', async (t) => {
           message: 'Author not found'
         }
       }
+    },
+
+    {
+      name: 'should run a query with multiple nested selections at the same level',
+      query: `{
+    getBook(id: 1) {
+      firstChapter {
+        title
+        pageCount
+      }
+      lastChapter {
+        title
+        pageCount
+      }
+    }
+  }`,
+      result: {
+        getBook: {
+          firstChapter: {
+            title: 'The Beginning',
+            pageCount: 20
+          },
+          lastChapter: {
+            title: 'The End',
+            pageCount: 25
+          }
+        }
+      }
     }
   ]
 


### PR DESCRIPTION
Hi all!

When executing a GraphQL query with parallel fields returning the same type with nested selections (like `firstChapter {title, pageCount} lastChapter {title, pageCount}`), the query builder incorrectly flattened nested fields because it added parent fields and subqueries separately, leading to malformed queries.

**Fix**:
Modified the nested field handling in buildQuerySelection to combine parent fields with their subqueries when adding to fields collection (`${selection[i].parentField} ${s.subquery}`), ensuring proper nesting structure is maintained.

Hope this helps!