### PR TITLE
fix: resolve non-provided optional variables to null

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -206,7 +206,7 @@ function unwrapVariable (varValue, varTypes) {
 
 function collectVariableArg (node, info, types) {
   const varName = node.name.value
-  const varValue = info.variableValues[varName]
+  const varValue = info.variableValues[varName] ?? null
   const varTypes = resolveVariableType(varName, varValue, info, types)
   return unwrapVariable(varValue, varTypes)
 }

--- a/test/fixtures/authors.js
+++ b/test/fixtures/authors.js
@@ -41,7 +41,7 @@ const schema = `
   type Author {
     id: ID
     name: AuthorName
-    todos(id: ID!): [AuthorTodo]
+    todos(id: ID): [AuthorTodo]
   }
 
   type BlogPostPublishEvent {
@@ -176,10 +176,10 @@ const resolvers = {
     }
   },
   Author: {
-    async todos (_, { id }) {
-      return Object.values(data.todos).filter((t) => {
-        return String(t.id) === id
-      })
+    async todos (root, { id }) {
+      return Object.values(data.todos).filter((t) =>
+        t.authorId === root.id && (id ? String(t.id) === id : true)
+      )
     }
   }
 }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -345,7 +345,7 @@ test('query capabilities', async (t) => {
           {
             id: '2',
             name: { firstName: 'John', lastName: 'Writer' },
-            todos: [{ task: 'Get really creative' }]
+            todos: []
           }
         ]
       }
@@ -365,7 +365,7 @@ test('query capabilities', async (t) => {
           {
             id: '2',
             name: { firstName: 'John', lastName: 'Writer' },
-            todos: [{ task: 'Write another book' }]
+            todos: []
           }
         ]
       }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -371,6 +371,26 @@ test('query capabilities', async (t) => {
       }
     },
     {
+      name: 'should run a query query with an optional variable argument that is not provided',
+      query:
+        'query GetAuthorListWithTodos ($id: ID) { list { id name { firstName lastName } todos(id: $id) { task } } }',
+      variables: {},
+      result: {
+        list: [
+          {
+            id: '1',
+            name: { firstName: 'Peter', lastName: 'Pluck' },
+            todos: [{ task: 'Write another book' }, { task: 'Get really creative' }]
+          },
+          {
+            id: '2',
+            name: { firstName: 'John', lastName: 'Writer' },
+            todos: []
+          }
+        ]
+      }
+    },
+    {
       name: 'should run multiple queries in a single request',
       query: `query {
         getBook(id: 2) { id genre }


### PR DESCRIPTION
When optional variables are not provided, they currently resolve to undefined rather than null. Since GraphQL only handles null values properly, this causes issues with expected handling of optional variables.

This PR modifies the behavior so that non-provided optional variables default to null instead of undefined. A new test case has been added to demonstrate this issue and verify the fix.