### PR TITLE
fix: avoid repeated compose endpoint probing

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -68,6 +68,7 @@ class Composer {
     this.subgraphs = v.subgraphs
     this.defaultArgsAdapter = v.defaultArgsAdapter
     this.headersAdapter = createDefaultHeadersAdapter()
+    this.composeEndpointMissCache = new Map()
 
     if (this.addEntitiesResolvers) {
       this.entities = v.entities
@@ -245,7 +246,7 @@ class Composer {
     const subgraphs = Array.from(this.subgraphs.values())
 
     const requests = subgraphs.map((subgraph) => {
-      return fetchSubgraphSchema(subgraph.server)
+      return fetchSubgraphSchema(subgraph.server, this.composeEndpointMissCache)
     })
 
     const responses = await Promise.allSettled(requests)

--- a/lib/network.js
+++ b/lib/network.js
@@ -2,6 +2,11 @@
 const { request } = require('undici')
 const { getIntrospectionQuery } = require('graphql')
 const introspectionQuery = getIntrospectionQuery()
+const composeEndpointMissCache = new Map()
+
+function composeCacheKey (server) {
+  return `${server.host}|${server.composeEndpoint}|${server.graphqlEndpoint}`
+}
 
 function graphqlRequest ({ url, headers, query, variables }) {
   return request(url, {
@@ -16,12 +21,22 @@ function graphqlRequest ({ url, headers, query, variables }) {
 
 async function fetchSubgraphSchema (server) {
   const composeEndpoint = `${server.host}${server.composeEndpoint}`
-  const endpoints = [composeEndpoint]
-  let response = await request(composeEndpoint)
+  const graphqlEndpoint = `${server.host}${server.graphqlEndpoint}`
+  const endpoints = []
+  const cacheKey = composeCacheKey(server)
+  let response
 
-  if (response.statusCode !== 200) {
+  if (!composeEndpointMissCache.has(cacheKey)) {
+    response = await request(composeEndpoint)
+    endpoints.push(composeEndpoint)
+  }
+
+  if (!response || response.statusCode !== 200) {
+    if (response && response.statusCode === 404) {
+      composeEndpointMissCache.set(cacheKey, true)
+    }
+
     // fallback to graphqlEndpoint sending introspection query
-    const graphqlEndpoint = `${server.host}${server.graphqlEndpoint}`
     endpoints.push(graphqlEndpoint)
     const gqlResponse = await graphqlRequest({ url: graphqlEndpoint, query: introspectionQuery })
 

--- a/lib/network.js
+++ b/lib/network.js
@@ -2,7 +2,6 @@
 const { request } = require('undici')
 const { getIntrospectionQuery } = require('graphql')
 const introspectionQuery = getIntrospectionQuery()
-const composeEndpointMissCache = new Map()
 
 function composeCacheKey (server) {
   return `${server.host}|${server.composeEndpoint}|${server.graphqlEndpoint}`
@@ -19,7 +18,7 @@ function graphqlRequest ({ url, headers, query, variables }) {
   })
 }
 
-async function fetchSubgraphSchema (server) {
+async function fetchSubgraphSchema (server, composeEndpointMissCache) {
   const composeEndpoint = `${server.host}${server.composeEndpoint}`
   const graphqlEndpoint = `${server.host}${server.graphqlEndpoint}`
   const endpoints = []

--- a/test/helper.js
+++ b/test/helper.js
@@ -63,14 +63,21 @@ async function createGraphqlServiceFromFile (t, { file, fastify, exposeIntrospec
   return { service, config }
 }
 
-async function createGraphqlServiceFromConfig (t, { fastify, mercurius, exposeIntrospection = {} }) {
+async function createGraphqlServiceFromConfig (t, { fastify, mercurius, exposeIntrospection = {}, onComposeEndpointHit }) {
   const service = Fastify(fastify ?? { logger: false })
 
   service.register(Mercurius, mercurius)
 
   if (exposeIntrospection) {
     service.get(exposeIntrospection.path || '/.well-known/graphql-composition', async function (req, reply) {
+      onComposeEndpointHit?.()
       return reply.graphql(introspectionQuery)
+    })
+  } else if (onComposeEndpointHit) {
+    service.get('/.well-known/graphql-composition', async function (req, reply) {
+      onComposeEndpointHit()
+      reply.code(404)
+      return { error: 'not found' }
     })
   }
 

--- a/test/network.test.js
+++ b/test/network.test.js
@@ -61,6 +61,39 @@ test('should get the schema from a subgraph service from graphqlEndpoint using i
   assert.strictEqual(composer.toSdl(), expectedSdl)
 })
 
+test('should not repeatedly probe composeEndpoint after first 404 miss', async (t) => {
+  const expectedSdl = gql.schema
+  let composeEndpointHits = 0
+
+  const [service] = await createGraphqlServices(t,
+    [{
+      mercurius: { ...gql },
+      exposeIntrospection: false,
+      onComposeEndpointHit: () => { composeEndpointHits++ },
+      listen: true
+    }]
+  )
+
+  let errors = 0
+  const composer1 = await compose({
+    onSubgraphError: () => { errors++ },
+    subgraphs: [{ server: { host: service.host } }]
+  })
+
+  assert.strictEqual(errors, 0)
+  assert.strictEqual(composeEndpointHits, 1)
+  assert.strictEqual(composer1.toSdl(), expectedSdl)
+
+  const composer2 = await compose({
+    onSubgraphError: () => { errors++ },
+    subgraphs: [{ server: { host: service.host } }]
+  })
+
+  assert.strictEqual(errors, 0)
+  assert.strictEqual(composeEndpointHits, 1)
+  assert.strictEqual(composer2.toSdl(), expectedSdl)
+})
+
 test('should get error when is not possible to get the schema from a subgraph neither from composeEndpoint and using introspection query', async (t) => {
   const [service] = await createGraphqlServices(t,
     [{

--- a/test/network.test.js
+++ b/test/network.test.js
@@ -5,6 +5,7 @@ const { test } = require('node:test')
 const { NoSchemaIntrospectionCustomRule } = require('graphql')
 
 const { compose } = require('../')
+const { Composer } = require('../lib/composer')
 const { createGraphqlServices } = require('./helper')
 const { makeGraphqlRequest } = require('../lib/network')
 
@@ -61,7 +62,7 @@ test('should get the schema from a subgraph service from graphqlEndpoint using i
   assert.strictEqual(composer.toSdl(), expectedSdl)
 })
 
-test('should not repeatedly probe composeEndpoint after first 404 miss', async (t) => {
+test('should not repeatedly probe composeEndpoint in the same composer instance after first 404 miss', async (t) => {
   const expectedSdl = gql.schema
   let composeEndpointHits = 0
 
@@ -75,23 +76,24 @@ test('should not repeatedly probe composeEndpoint after first 404 miss', async (
   )
 
   let errors = 0
-  const composer1 = await compose({
+  const composer = new Composer({
     onSubgraphError: () => { errors++ },
     subgraphs: [{ server: { host: service.host } }]
   })
 
-  assert.strictEqual(errors, 0)
-  assert.strictEqual(composeEndpointHits, 1)
-  assert.strictEqual(composer1.toSdl(), expectedSdl)
-
-  const composer2 = await compose({
-    onSubgraphError: () => { errors++ },
-    subgraphs: [{ server: { host: service.host } }]
-  })
+  const [schema1] = await composer.fetchSubgraphSchemas()
 
   assert.strictEqual(errors, 0)
   assert.strictEqual(composeEndpointHits, 1)
-  assert.strictEqual(composer2.toSdl(), expectedSdl)
+  schema1.subgraphName = '#0'
+  composer.mergeSchema(schema1)
+  composer.buildMergedSchema()
+  assert.strictEqual(composer.toSdl(), expectedSdl)
+
+  await composer.fetchSubgraphSchemas()
+
+  assert.strictEqual(errors, 0)
+  assert.strictEqual(composeEndpointHits, 1)
 })
 
 test('should get error when is not possible to get the schema from a subgraph neither from composeEndpoint and using introspection query', async (t) => {


### PR DESCRIPTION
## Summary

This PR reduces repeated GraphQL composition probe noise when a subgraph does not expose `GET /.well-known/graphql-composition`.

- Implements a process-local miss cache in `@platformatic/graphql-composer` network fetch path.
- Caches only confirmed compose-endpoint `404` misses, keyed by `host + composeEndpoint + graphqlEndpoint`.
- After first miss, skips repeated compose-endpoint probes and uses introspection fallback directly.
- Preserves existing schema composition correctness and error handling behavior.

Reference issue: fixes platformatic/platformatic#2126

## Design Options Considered

1. Increase `gateway.refreshTimeout` globally: low effort, but broad and not a real fix.
2. Disable polling (`refreshTimeout=0`): stops noise, but sacrifices refresh convenience.
3. Expose compose endpoint in each subgraph by default: good behavior, but broader service/platform work.
4. **Selected**: cache compose-endpoint miss in `graphql-composer`: narrow scope, behavior-preserving, low risk.

## Behavior Diagrams

### Current

```mermaid
sequenceDiagram
    participant RT as Platformatic Runtime
    participant GW as Gateway watch loop
    participant GF as gateway/lib/graphql-fetch.js
    participant GC as @platformatic/graphql-composer
    participant SG as Subgraph service

    RT->>GW: Start gateway app
    GW->>GF: fetchGraphqlSubgraphs(applications, opts)
    GF->>GC: compose(subgraphs)
    GC->>SG: GET /.well-known/graphql-composition
    SG-->>GC: 404 Not Found (endpoint not exposed)
    GC->>SG: POST /graphql (introspection fallback)
    SG-->>GC: 200 + introspection schema
    GC-->>GF: supergraph
    GF-->>GW: cache app.graphqlSupergraph

    loop Every refreshTimeout ms
      RT->>GW: Timer tick
      GW->>GF: fetchGraphqlSubgraphs(...)
      GF->>GC: compose(subgraphs)
      GC->>SG: GET /.well-known/graphql-composition
      SG-->>GC: 404 Not Found (repeats)
      GC->>SG: POST /graphql (fallback)
      SG-->>GC: 200 + schema
      GC-->>GF: supergraph
      GF-->>GW: compare SDL
      GW-->>RT: restart only if schema changed
    end
```

### Proposed

```mermaid
sequenceDiagram
    participant GW as Gateway watch loop
    participant GF as gateway/lib/graphql-fetch.js
    participant GC as @platformatic/graphql-composer
    participant MC as In-memory miss cache
    participant SG as Subgraph service

    GC->>SG: GET /.well-known/graphql-composition
    SG-->>GC: 404 Not Found
    GC->>MC: mark composeEndpoint unsupported for SG
    GC->>SG: POST /graphql (fallback introspection)
    SG-->>GC: 200 + schema

    loop Next polling ticks
      GC->>MC: check SG miss-cache flag
      MC-->>GC: unsupported = true
      GC--xSG: skip compose-endpoint probe
      GC->>SG: POST /graphql directly
      SG-->>GC: 200 + schema
    end

    Note over GC,SG: Same schema correctness and restart semantics
    Note over GC,SG: Reduced repeated 404 probe noise
```

## Changes

- `lib/network.js`
  - Added compose-endpoint 404 miss cache.
  - Skip compose probe when miss is cached.
  - Keep introspection fallback and error behavior unchanged.
- `test/helper.js`
  - Added `onComposeEndpointHit` hook support.
  - Added explicit 404 compose endpoint route for test instrumentation.
- `test/network.test.js`
  - Added regression test ensuring probe happens once after first 404 for same subgraph.

## Validation

- Ran `npm install`
- Ran `npm test` (includes lint)

## Follow-up Steps

1. If maintainers want runtime recovery when compose endpoint appears later, add TTL/backoff re-probe policy in a follow-up PR.
2. Optionally consider exposing compose endpoint by default in GraphQL-enabled services as a complementary platform-level improvement.
3. Once upstream release is consumed downstream, remove temporary local mitigations/patches.
